### PR TITLE
Fix typo and value of OUTPUT_TYPE_SELECT define.

### DIFF
--- a/bma2x2.h
+++ b/bma2x2.h
@@ -1740,7 +1740,7 @@ BMA2x2_INTR_SOURCE_ADDR
 /***************************************************/
 #define OPEN_DRAIN	(0x01)
 /**< It refers open drain selection*/
-#define PUSS_PULL	(0x01)
+#define PUSH_PULL	(0x00)
 /**< It refers push pull selection*/
 
 /****************************************************/


### PR DESCRIPTION
There are both a typo and a wrong defition, checked against BMA253's
datasheet revision 1.0.